### PR TITLE
attempt to produce an EBNF grammar definition

### DIFF
--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -17,6 +17,7 @@
 
 **function signature** =
   [ **identifier** ] , "(" , [ **parameters** ] ,  ")" ,
+  "=>", [ **identifier** , [ "?" ] ":" ] , **type** ,
   { [ "," ] , **function trailer** } ;
   (\* parser should confirm semantics, allow 1 of each function trailer \*)
 
@@ -67,8 +68,7 @@
 
 **spread parameter** = "..." , **identifier** , ":" , **array type** ;
 
-**function trailer** = ( "=>", [ **identifier** , [ "?" ] ":" ] , **type** )
-                     | ( "requires" , ":" , **value expressions** )
+**function trailer** = ( "requires" , ":" , **value expressions** )
                      | ( "throws" , [ ":" , **identifier** ] ) ;
 
 

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -33,7 +33,10 @@
 **function signatures** =
   **function signature** , { "," , **function signature** } ;
 
-**parameters** = **parameter** , { "," , **parameter** } ;
+**parameters** = **spread parameter**
+               | **parameter** , { "," , **parameter** } , [ "," , **spread parameter** ]
+
+Note: inspired by [ES2015 FormalParameterList](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-function-definitions)
 
 **identifier** =
   ( **identifier character** , { **identifier character** } ) - **reserved word** ;
@@ -55,7 +58,6 @@
 
 **parameter** = **type**
               | **named parameter**
-              | **spread parameter**
               | **destructured object** ;
 
 **named parameter** =

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -1,0 +1,49 @@
+# [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form)
+
+**function signature** =
+  [ **identifier** ] , "(" , [ **parameter list** ] ,  ")" ,
+  "=>", [ **identifier** , ":" ] , **type** ,
+  [ "requires" , ":" , **value expressions** ] ,
+  [ "throws" , [ ":" , **identifier** ] ] ;
+
+**parameter list** = **parameter** , { "," , **parameter** } ;
+
+**parameter** = ( [ **identifier** , ":" ] , **type** ) | **spread parameter** ;
+
+**spread parameter** = "..." , **identifier** , ":" , **array type** ;
+
+**type** = **array type**
+         | **non-array type**
+         | **union type** ;
+
+**union type** = **type** , { "|" , **type** } ;
+
+**array type** = **non-array type** , "[" , "]" ;
+
+**non-array type** = **identifier**
+                   | **builtin type**
+                   | **literal type** ;
+
+**identifier** =
+  ( **identifier character** , { **identifier character** } ) - **reserved word** ;
+
+**value expressions** = **value expression** , { "," , **value expression** } ;
+
+**literal type** = ? set of JavaScript-legal literal values ? ;
+
+**identifier character** = ? set of JavaScript-legal identifier characters ? ;
+
+**reserved word** = ? set of JavaScript and rtype reserved words ? ;
+
+**builtin type** = "Any"
+                 | "Array"
+                 | "Boolean"
+                 | "Function"
+                 | "Number"
+                 | "Object"
+                 | "String"
+                 | "Void"
+                 | "Predicate" ;
+
+**value expression** = ? JavaScript-legal variable, dot-property or array-access ? ;
+  (* e.g. document, navigator.geolocation, String.prototype.trim *)

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -1,13 +1,21 @@
 # [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form)
 
-**interface** =
-  "interface" , **identifier** ,
-  ( [ **predicate literal** ] , "{" , **parameter list** , "}" )
-  | ( **predicate literal** , [ "{" , **parameter list** , "}" ] ) ;
-  (\* interface has at least one of predicate literal or parameter list \*)
-
 **minimal interface** = "interface" , **identifier** ,
   ( ":" , **type** ) | **predicate literal**;
+
+**interface** =
+  "interface" , **identifier** ,
+  ( [ **predicate literal** ] , "{" , **interface property list** , "}" )
+  | ( **predicate literal** , [ "{" , **interface property list** , "}" ] ) ;
+  (\* interface has one or both but never neither \*)
+
+**interface property list** =
+  **interface property** , { "," , **interface property** } ;
+
+**interface property** = **parameter**
+                       | **object spread property** ;
+
+**object spread property** = "..." , **identifier** , "?" ;
 
 **function interface** =
   "interface" , **identifier** , "{" , **function signatures** , "}" ;

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -1,35 +1,57 @@
 # [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form)
 
+
+## Entry Points
+
 **minimal interface** = "interface" , **identifier** ,
   ( ":" , **type** ) | **predicate literal**;
 
 **interface** =
   "interface" , **identifier** ,
-  ( [ **predicate literal** ] , "{" , **object property list** , "}" )
-  | ( **predicate literal** , [ "{" , **object property list** , "}" ] ) ;
+  ( [ **predicate literal** ] , "{" , **object properties** , "}" )
+  | ( **predicate literal** , [ "{" , **object properties** , "}" ] ) ;
   (\* interface has one or both but never neither \*)
 
-**object property list** =
+**function interface** =
+  "interface" , **identifier** , "{" , **function signatures** , "}" ;
+
+**function signature** =
+  [ **identifier** ] , "(" , [ **parameters** ] ,  ")" ,
+  "=>", [ **identifier** , [ "?" ] ":" ] , **type** ,
+  [ "requires" , ":" , **value expressions** ] ,
+  [ "throws" , [ ":" , **identifier** ] ] ;
+
+
+## Non-Terminal Production Rules
+
+
+### Repeaters (length >= 1)
+
+**object properties** =
   **object property** , { "," , **object property** } ;
+
+**function signatures** =
+  **function signature** , { "," , **function signature** } ;
+
+**parameters** = **parameter** , { "," , **parameter** } ;
+
+**identifier** =
+  ( **identifier character** , { **identifier character** } ) - **reserved word** ;
+
+**value expressions** = **value expression** , { "," , **value expression** } ;
+
+
+### Objects
+
+**destructured object** = "{" , **object properties** , "}" ;
 
 **object property** = **parameter**
                        | **object spread property** ;
 
 **object spread property** = "..." , **identifier** , "?" ;
 
-**function interface** =
-  "interface" , **identifier** , "{" , **function signatures** , "}" ;
 
-**function signatures** =
-  **function signature** , { "," , **function signature** } ;
-
-**function signature** =
-  [ **identifier** ] , "(" , [ **parameter list** ] ,  ")" ,
-  "=>", [ **identifier** , [ "?" ] ":" ] , **type** ,
-  [ "requires" , ":" , **value expressions** ] ,
-  [ "throws" , [ ":" , **identifier** ] ] ;
-
-**parameter list** = **parameter** , { "," , **parameter** } ;
+### Parameters
 
 **parameter** = **type**
               | **named parameter**
@@ -46,7 +68,9 @@
 
 **spread parameter** = "..." , **identifier** , ":" , **array type** ;
 
-**destructured object** = "{" , **object property list** , "}" ;
+
+
+### Types
 
 **type** = **array type**
          | **non-array type**
@@ -60,10 +84,8 @@
                    | **builtin type**
                    | **literal type** ;
 
-**identifier** =
-  ( **identifier character** , { **identifier character** } ) - **reserved word** ;
 
-**value expressions** = **value expression** , { "," , **value expression** } ;
+## Terminal Production Rules and JavaScript
 
 **literal type** = ? set of JavaScript-legal literal values ? | **regexp literal**;
 

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -1,5 +1,20 @@
 # [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form)
 
+**interface** =
+  "interface" , **identifier** ,
+  ( [ **predicate literal** ] , "{" , **parameter list** , "}" )
+  | ( **predicate literal** , [ "{" , **parameter list** , "}" ] ) ;
+  (\* interface has at least one of predicate literal or parameter list \*)
+
+**minimal interface** = "interface" , **identifier** ,
+  ( ":" , **type** ) | **predicate literal**;
+
+**function interface** =
+  "interface" , **identifier** , "{" , **function signatures** , "}" ;
+
+**function signatures** =
+  **function signature** , { "," , **function signature** } ;
+
 **function signature** =
   [ **identifier** ] , "(" , [ **parameter list** ] ,  ")" ,
   "=>", [ **identifier** , [ "?" ] ":" ] , **type** ,
@@ -29,7 +44,11 @@
 
 **value expressions** = **value expression** , { "," , **value expression** } ;
 
-**literal type** = ? set of JavaScript-legal literal values ? ;
+**literal type** = ? set of JavaScript-legal literal values ? | **regexp literal**;
+
+**predicate literal** = ? JavaScript-legal arrow function ? , ";" ;
+
+**regexp literal** = "/" , ? JavaScript-legal Regular Expression characters ? , "/" ;
 
 **identifier character** = ? set of JavaScript-legal identifier characters ? ;
 
@@ -46,4 +65,4 @@
                  | "Predicate" ;
 
 **value expression** = ? JavaScript-legal variable, dot-property or array-access ? ;
-  (* e.g. document, navigator.geolocation, String.prototype.trim *)
+  (\* e.g. document, navigator.geolocation, String.prototype.trim \*)

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -2,7 +2,7 @@
 
 **function signature** =
   [ **identifier** ] , "(" , [ **parameter list** ] ,  ")" ,
-  "=>", [ **identifier** , ":" ] , **type** ,
+  "=>", [ **identifier** , [ "?" ] ":" ] , **type** ,
   [ "requires" , ":" , **value expressions** ] ,
   [ "throws" , [ ":" , **identifier** ] ] ;
 

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -31,7 +31,17 @@
 
 **parameter list** = **parameter** , { "," , **parameter** } ;
 
-**parameter** = ( [ **identifier** , ":" ] , **type** ) | **spread parameter** ;
+**parameter** = **type**
+              | **named parameter**
+              | **spread parameter** ;
+
+**named parameter** =
+  **identifier** ,
+  ( [ **default value** ] ":" , **type** )
+  | ( **default value** ":" , [ **type** ] );
+  (\* named parameter has one or both but never neither \*)
+
+**default value** = "=" , **literal type** ;
 
 **spread parameter** = "..." , **identifier** , ":" , **array type** ;
 

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -5,14 +5,14 @@
 
 **interface** =
   "interface" , **identifier** ,
-  ( [ **predicate literal** ] , "{" , **interface property list** , "}" )
-  | ( **predicate literal** , [ "{" , **interface property list** , "}" ] ) ;
+  ( [ **predicate literal** ] , "{" , **object property list** , "}" )
+  | ( **predicate literal** , [ "{" , **object property list** , "}" ] ) ;
   (\* interface has one or both but never neither \*)
 
-**interface property list** =
-  **interface property** , { "," , **interface property** } ;
+**object property list** =
+  **object property** , { "," , **object property** } ;
 
-**interface property** = **parameter**
+**object property** = **parameter**
                        | **object spread property** ;
 
 **object spread property** = "..." , **identifier** , "?" ;
@@ -33,7 +33,8 @@
 
 **parameter** = **type**
               | **named parameter**
-              | **spread parameter** ;
+              | **spread parameter**
+              | **destructured object** ;
 
 **named parameter** =
   **identifier** ,
@@ -44,6 +45,8 @@
 **default value** = "=" , **literal type** ;
 
 **spread parameter** = "..." , **identifier** , ":" , **array type** ;
+
+**destructured object** = "{" , **object property list** , "}" ;
 
 **type** = **array type**
          | **non-array type**

--- a/docs/ebnf.md
+++ b/docs/ebnf.md
@@ -4,7 +4,7 @@
 ## Entry Points
 
 **minimal interface** = "interface" , **identifier** ,
-  ( ":" , **type** ) | **predicate literal**;
+  ( ":" , **type** ) | **predicate literal** ;
 
 **interface** =
   "interface" , **identifier** ,
@@ -17,9 +17,8 @@
 
 **function signature** =
   [ **identifier** ] , "(" , [ **parameters** ] ,  ")" ,
-  "=>", [ **identifier** , [ "?" ] ":" ] , **type** ,
-  [ "requires" , ":" , **value expressions** ] ,
-  [ "throws" , [ ":" , **identifier** ] ] ;
+  { [ "," ] , **function trailer** } ;
+  (\* parser should confirm semantics, allow 1 of each function trailer \*)
 
 
 ## Non-Terminal Production Rules
@@ -68,6 +67,9 @@
 
 **spread parameter** = "..." , **identifier** , ":" , **array type** ;
 
+**function trailer** = ( "=>", [ **identifier** , [ "?" ] ":" ] , **type** )
+                     | ( "requires" , ":" , **value expressions** )
+                     | ( "throws" , [ ":" , **identifier** ] ) ;
 
 
 ### Types

--- a/docs/rtype.l
+++ b/docs/rtype.l
@@ -1,0 +1,24 @@
+NAME                            [a-zA-Z_][a-zA-Z0-9_-]+\b
+NUMBER                          [0-9]+("."[0-9]+)?\b
+
+%%
+
+/*
+copying some relevant looking bits from
+https://github.com/zaach/jison/blob/master/examples/calculator.jison
+*/
+
+\s+                             /* skip whitespace */
+{NAME}                          return yytext
+{NUMBER}                        return yytext
+<<EOF>>                         return 'EOF'
+
+/*
+ECMAScript specification: section 11.4
+http://www.ecma-international.org/ecma-262/6.0/index.html#sec-comments
+*/
+
+"/*"(.|\n|\r)*?"*/"             /* ignore */
+"//".*                          /* ignore */
+
+%%

--- a/docs/rtype.y
+++ b/docs/rtype.y
@@ -1,0 +1,66 @@
+%start spec
+
+/* grammar for parsing rtype */
+
+%%
+
+spec
+    :
+    | ReservedWord EOF
+    ;
+
+/*
+ECMAScript specification: section 11.6
+http://www.ecma-international.org/ecma-262/6.0/index.html#sec-names-and-keywords
+*/
+
+/*
+ECMAScript specification: section 11.6.2
+http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reserved-words
+*/
+
+ReservedWord
+    : Keyword
+    | FutureReservedWord
+    | NullLiteral
+    | BooleanLiteral
+    ;
+
+Keyword
+    : 'break'	 | 'do'       | 'in'         | 'typeof'
+    | 'case'     | 'else'     | 'instanceof' | 'var'
+    | 'catch'    | 'export'   | 'new'        | 'void'
+    | 'class'    | 'extends'  | 'return'     | 'while'
+    | 'const'    | 'finally'  | 'super'      | 'with'
+    | 'continue' | 'for'      | 'switch'     | 'yield'
+    | 'debugger' | 'function' | 'this'
+    | 'default'  | 'if'       | 'throw'
+    | 'delete'   | 'import'   | 'try'
+    ;
+
+FutureReservedWord
+    : 'enum' | 'await'
+    /* strict mode reserved words below */
+    | 'implements' | 'package' | 'protected'
+    | 'interface'  | 'private' | 'public'
+    ;
+
+/*
+ECMAScript specification: section 11.8.1
+http://www.ecma-international.org/ecma-262/6.0/index.html#sec-null-literals
+*/
+
+NullLiteral
+    : 'null'
+    ;
+
+/*
+ECMAScript specification: section 11.8.2
+http://www.ecma-international.org/ecma-262/6.0/index.html#sec-boolean-literals
+*/
+
+BooleanLiteral
+    : 'true' | 'false'
+    ;
+
+%%

--- a/package.json
+++ b/package.json
@@ -36,8 +36,11 @@
     "babel-cli": "^6.2.0",
     "babel-eslint": "^5.0.0-beta4",
     "babel-preset-es2015": "^6.1.18",
+    "ebnf-parser": "^0.1.10",
     "eslint": "^1.10.2",
-    "rimraf": "^2.4.4",
+    "jison": "^0.4.17",
+    "lex-parser": "^0.1.4",
+    "rimraf": "2.5.2",
     "tape": "^4.2.2",
     "watch": "^0.16.0"
   },

--- a/test/ebnf/index.js
+++ b/test/ebnf/index.js
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+
+import ebnfParser from 'ebnf-parser';
+import lexParser from 'lex-parser';
+import { Parser } from 'jison';
+import rimraf from 'rimraf';
+import test from 'tape';
+
+const ebnfPath = path.join(__dirname, '..', '..', 'docs', 'rtype.y');
+const ebnf = fs.readFileSync(ebnfPath, 'utf8');
+
+const lexPath = path.join(__dirname, '..', '..', 'docs', 'rtype.l');
+const lex = fs.readFileSync(lexPath, 'utf8');
+
+let grammar;
+
+test('ebnfParser parses rtype.ebnf into grammar JSON', (t) => {
+  grammar = ebnfParser.parse(ebnf);
+  t.ok(grammar);
+  t.equals(typeof grammar, 'object');
+  t.end();
+});
+
+let lexer;
+
+test('lexParser parses rtype.ebnf into lex JSON', (t) => {
+  lexer = lexParser.parse(lex);
+  t.ok(lexer);
+  t.equals(typeof lexer, 'object');
+  t.end();
+});
+
+let parser;
+
+test('grammar JSON transforms into parser', (t) => {
+  grammar.lex = lexer;
+  parser = Parser(grammar);
+  t.ok(parser);
+  t.equal(typeof parser.parse, 'function');
+  t.end();
+});
+
+test(`parse('break')`, (t) => {
+  let result;
+  t.doesNotThrow(() => {
+    result = parser.parse('break');
+  }, Error);
+  t.ok(result);
+  t.end();
+});
+
+test(`parse('unspecified') throws`, (t) => {
+  t.throws(() => {
+    parser.parse('unspecified');
+  });
+  t.end();
+});
+
+let parserSource;
+let tmpDir;
+let parserPath;
+
+test.onFinish(() => {
+  rimraf.sync(tmpDir);
+});
+
+test('parserSource', (t) => {
+  parserSource = parser.generate();
+  t.ok(parserSource);
+  t.equal(typeof parserSource, 'string');
+
+  fs.mkdtemp('/tmp/rtype-ebnf-', (err, dirPath) => {
+    t.error(err);
+    tmpDir = dirPath;
+
+    parserPath = path.join(tmpDir, 'parser.js');
+    fs.writeFileSync(parserPath, parserSource, 'utf8');
+    t.end();
+  });
+});
+
+test('generated parser.js', (t) => {
+  const parse = require(parserPath).parse;
+  t.equal(typeof parse, 'function');
+  t.end();
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -18,3 +18,4 @@ test('rtype(type: Predicate | String) => Predicate', (t) => {
 });
 
 import './builtins';
+import './ebnf/index.js';


### PR DESCRIPTION
After doing the smallest amount of reading, it seemed like a good idea to have an EBNF document before starting work on tokenisers and parsers.

So here's what I have so far.

The special sequences (e.g. `? ... ?`) probably need to be defined explicitly.
- [x] initial spec written in pseudo-EBNF in a Markdown document
- [x] RtypeInterfaces defined in pseudo-EBNF
- [x] clarify RtypeFunction trailers in pseudo-EBNF
- [x] rewrite a small part of the spec in a format that works with https://github.com/zaach/ebnf-parser
- [ ] [return type should be optional](https://github.com/ericelliott/rtype/pull/42#issuecomment-210721514)
- [ ] [Iterable type](https://github.com/ericelliott/rtype#the-iterable-type)
- [ ] [RTFunctionSignature](https://github.com/ericelliott/rtype#reading-function-signatures)
- [ ] [RTInterface](https://github.com/ericelliott/rtype#interface-user-defined-types)
- [ ] [RTConciseInterface](https://github.com/ericelliott/rtype#interface-user-defined-types)
- [ ] [RTFunctionInterface](https://github.com/ericelliott/rtype#interface-user-defined-types)
- [ ] whole spec rewritten in this format
- [ ] spec using terminology from http://www.ecma-international.org/publications/standards/Ecma-262.htm
- [ ] clarify terminology for new non-ES2015 grammar
- [ ] spec transformed into parser with https://github.com/zaach/jison
