### PR TITLE
Add `npm run toc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,33 @@ This repository is for the notation documentation and parser.
 If you're interested in using rtype to build interfaces in your standard JavaScript code, see [rfx](https://github.com/ericelliott/rfx).
 
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [About Rtype](#about-rtype)
+- [What is Rtype?](#what-is-rtype)
+- [Status: RFC](#status-rfc)
+- [Why?](#why)
+- [Why Not Just Use TypeScript?](#why-not-just-use-typescript)
+- [Reading Function Signatures](#reading-function-signatures)
+  - [Optional Parameters](#optional-parameters)
+  - [Array Types](#array-types)
+  - [Union Types](#union-types)
+  - [Literal Types](#literal-types)
+  - [Builtin Types](#builtin-types)
+    - [The `Any` Type](#the-any-type)
+    - [The `Void` Type](#the-void-type)
+    - [The `Predicate` Type](#the-predicate-type)
+  - [Throwing functions](#throwing-functions)
+  - [Dependencies](#dependencies)
+- [Interface: User Defined Types](#interface-user-defined-types)
+- [Comments](#comments)
+- [References](#references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
 ## About Rtype
 
 * Great for simple documentation.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "babel -d build source -s",
     "test": "babel-node test/index.js",
     "check": "npm run -s lint && npm -s test && npm -s run build",
+    "toc": "doctoc README.md",
     "watch": "watch 'clear && npm run -s lint && npm -s test' source test"
   },
   "directories": {
@@ -36,6 +37,7 @@
     "babel-cli": "^6.2.0",
     "babel-eslint": "^5.0.0-beta4",
     "babel-preset-es2015": "^6.1.18",
+    "doctoc": "^0.15.0",
     "eslint": "^1.10.2",
     "rimraf": "^2.4.4",
     "tape": "^4.2.2",


### PR DESCRIPTION
Closes #39.

We can use [_husky_](http://npm.im/husky) to auto-rerender the TOC on every commit. Shall I give it a go?
