### PR TITLE
Add precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "babel-node test/index.js",
     "check": "npm run -s lint && npm -s test && npm -s run build",
     "toc": "doctoc README.md",
+    "precommit": "git diff --staged --exit-code README.md || (npm run toc && git add README.md)",
     "watch": "watch 'clear && npm run -s lint && npm -s test' source test"
   },
   "directories": {
@@ -39,6 +40,7 @@
     "babel-preset-es2015": "^6.1.18",
     "doctoc": "0.15.0",
     "eslint": "^1.10.2",
+    "husky": "^0.10.2",
     "rimraf": "^2.4.4",
     "tape": "^4.2.2",
     "watch": "^0.16.0"


### PR DESCRIPTION
See #51.

A TOC will now be rerendered anytime you commit changes to the readme.

Remember to `npm install` so that husky sets its hooks.
