### PR TITLE
Add “Composing types”

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If you're interested in using rtype to build interfaces in your standard JavaScr
   - [Throwing functions](#throwing-functions)
   - [Dependencies](#dependencies)
 - [Interface: User Defined Types](#interface-user-defined-types)
+- [Composing types](#composing-types)
 - [Comments](#comments)
 - [References](#references)
 
@@ -412,6 +413,7 @@ interface Human {
 To make sure we can run a static type check for you, we don’t allow merging two different literals. So this would result in a compile error:
 
 ```js
+// Invalid!
 interface Professor {
   ...Human,
   name: /^prof\. \w+$/,
@@ -421,6 +423,7 @@ interface Professor {
 Obviusly, merging incompatible interfaces is also invalid:
 
 ```js
+// Invalid!
 interface Bot {
   ...Creature,
   name: Number,

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ interface Company {
 }
 ```
 
-In case of a name conflict, both properties must be satisfied. Keep that in mind that many types aren’t compatible with one another – for example, `Number` and `String`:
+In case of a name conflict, properties with same names are merged. It means all prerequisites must be satisfied. It’s fine to make types more specific through type literals:
 
 ```js
 interface Creature {
@@ -402,18 +402,28 @@ interface Creature {
   strength: (number) => (number >= 0 && number <= 100),
 }
 
-// This is OK:
 interface Human {
   ...Creature,
-  name: /^[A-Z][a-z]+$/,
+  name: /^(.* )?[A-Z][a-z]+$/,
   character: 'friendly' | 'grumpy',
 }
+```
 
-// This will never be satisfied:
-interface Animal {
+To make sure we can run a static type check for you, we don’t allow merging two different literals. So this would result in a compile error:
+
+```js
+interface Professor {
   ...Human,
-  name: 'dog' | 'cat' | 'frog',
-  strength: 'strong' | 'weak',
+  name: /^prof\. \w+$/,
+}
+```
+
+Obviusly, merging incompatible interfaces is also invalid:
+
+```js
+interface Bot {
+  ...Creature,
+  name: Number,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -316,18 +316,6 @@ interface Collection {
 ```
 
 
-Interfaces support object spread:
-
-```js
-interface User {
-  name: String,
-  avatarUrl?: Url,
-  about?: String,
-  ...properties? // type Object is inferred
-}
-```
-
-
 Interfaces support builtin literal types:
 
 ```js
@@ -369,6 +357,63 @@ interface EnhancedInteger (number) => {
 }; {
   isDivisibleBy3() => Boolean,
   double() => Number
+}
+```
+
+
+## Composing types
+
+Whenever you want to compose an interface out of several others, use the spread operator for that:
+
+```js
+interface Person {
+  name: Name,
+  birthDate: Number,
+}
+
+interface User {
+  username: String,
+  description?: String,
+  kudos = 0: Number,
+}
+
+interface HumanUser {
+  ...Person,
+  ...User,
+  avatarUrl: String,
+}
+```
+
+You can also use the spread inside object type literals:
+
+```js
+interface Company {
+  name: Name,
+  owner: { ...Person, shareStake: Number },
+}
+```
+
+In case of a name conflict, both properties must be satisfied. Keep that in mind that many types aren’t compatible with one another – for example, `Number` and `String`:
+
+```js
+interface Creature {
+  name: String,
+  character: String,
+  strength: (number) => (number >= 0 && number <= 100),
+}
+
+// This is OK:
+interface Human {
+  ...Creature,
+  name: /^[A-Z][a-z]+$/,
+  character: 'friendly' | 'grumpy',
+}
+
+// This will never be satisfied:
+interface Animal {
+  ...Human,
+  name: 'dog' | 'cat' | 'frog',
+  strength: 'strong' | 'weak',
 }
 ```
 


### PR DESCRIPTION
Fixes #9.

This is also my contribution to the discussion on interface collisions. I think it should be valid to override more generic types like `String` with more specific ones like `/^[a-z]+$/`.
