### PR TITLE
expanded version of the optional parameter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,8 +416,7 @@ interface Collection {
 }
 
 // in JS:
-// typeof Collection ==
-'function'
+// typeof Collection == 'function'
 // typeof Collection.method1 === 'function'
 // typeof Collection.method2 === 'function'
 ```

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ interface Collection {
 }
 
 // in JS:
-// typeof Collection == 'function'
+// typeof Collection === 'function'
 // typeof Collection.method1 === 'function'
 // typeof Collection.method2 === 'function'
 ```

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ Optional parameters can be indicated with `?`:
 (param: Type, optParam?: Type) => ReturnType
 ```
 
+Is equivalent to:
+
+```js
+(param: Type, optParam = undefined: Type) => ReturnType
+```
+
 ### Anonymous Parameters
 
 Parameter names can be omitted:
@@ -410,7 +416,8 @@ interface Collection {
 }
 
 // in JS:
-// typeof Collection === 'function'
+// typeof Collection ==
+'function'
 // typeof Collection.method1 === 'function'
 // typeof Collection.method2 === 'function'
 ```


### PR DESCRIPTION
This resolves the concern raised in #111 by being more explicit.
For convenience, the specification assumes that undefined is read-only.