### PR TITLE
Removed interfaces.rtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ If you're interested in using rtype to build interfaces in your standard JavaScr
 - [Composing types](#composing-types)
 - [Event Emitters](#event-emitters)
 - [Comments](#comments)
-- [`interfaces.rtype`](#interfacesrtype)
 - [References](#references)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/README.md
+++ b/README.md
@@ -654,13 +654,6 @@ Standard JS comment syntax applies, e.g.:
 ```
 
 
-## `interfaces.rtype`
-
-If you find yourself using the same custom types all over your project, you can keep their definitions in one `interfaces.rtype` file in the root of the project. Don’t forget to set up your editor so that it treats `*.rtype` files as JavaScript.
-
-At the moment you can use this file for documenting your project. But we’re soon rolling out analysis tools for rtype. In the future they will be able to import the file and use your definitions for static type analysis.
-
-
 ## References
 
 Somewhat related ideas and inspiration sources.


### PR DESCRIPTION
AFAIK, nothing is using the interfaces.rtype spec yet, and there are lots of other potential ways you could declare and import shared types for projects.

Note: comments *are* being used in rtype for documentation purposes. Keeping that section.